### PR TITLE
Add settings modal for difficulty and input lag adjustment

### DIFF
--- a/assets/js/analysis.js
+++ b/assets/js/analysis.js
@@ -58,7 +58,8 @@
   function scheduleNoteFromOnset(state, onsetTimeSec, lane) {
     const travelDist = Math.max(0, state.hitY - (NOTE_H / 2));
     const travelTimeMs = (travelDist / SPEED) * 1000;
-    const hitPerfMs = state.startAt + ((onsetTimeSec - state.audioBaseTime) * 1000) + window.RG.Const.ANALYSIS_DELAY_MS;
+    const userOffsetMs = (window.RG.Settings && window.RG.Settings.getInputOffsetMs()) || 0;
+    const hitPerfMs = state.startAt + ((onsetTimeSec - state.audioBaseTime) * 1000) + window.RG.Const.ANALYSIS_DELAY_MS + userOffsetMs;
     const spawnRelMs = hitPerfMs - travelTimeMs - state.startAt;
 
     const def = { t: spawnRelMs, lane };

--- a/assets/js/dom.js
+++ b/assets/js/dom.js
@@ -21,6 +21,15 @@
   const comboValueEl = comboEl ? comboEl.querySelector('.value') : null;
   const comboToastEl = $('#comboToast');
 
+  // Settings modal elements
+  const openSettingsBtn = $('#openSettingsBtn');
+  const settingsModal = $('#settingsModal');
+  const settingsDifficulty = $('#settingsDifficulty');
+  const inputLagRange = $('#inputLag');
+  const inputLagNumber = $('#inputLagNumber');
+  const settingsSave = $('#settingsSave');
+  const settingsCancel = $('#settingsCancel');
+
   window.RG.Dom = {
     playfield,
     judgementEl,
@@ -36,6 +45,13 @@
     difficultySelect,
     comboEl,
     comboValueEl,
-    comboToastEl
+    comboToastEl,
+    openSettingsBtn,
+    settingsModal,
+    settingsDifficulty,
+    inputLagRange,
+    inputLagNumber,
+    settingsSave,
+    settingsCancel
   };
 })();

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -22,9 +22,10 @@
 
     const travelDist = Math.max(0, state.hitY - (window.RG.Const.NOTE_H / 2));
     const travelTimeMs = (travelDist / window.RG.Const.SPEED) * 1000;
+    const userOffsetMs = (window.RG.Settings && window.RG.Settings.getInputOffsetMs()) || 0;
 
     state.schedule = chart.notes.map(n => ({
-      t: Math.max(0, n.timeMs - travelTimeMs),
+      t: Math.max(0, (n.timeMs + userOffsetMs) - travelTimeMs),
       lane: n.lane
     }));
     state.schedule.sort((a, b) => a.t - b.t);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,9 @@
 (() => {
+  // Initialize settings (load persisted difficulty/input offset and wire modal)
+  if (window.RG.Settings && window.RG.Settings.init) {
+    window.RG.Settings.init();
+  }
+
   // Initialize state
   window.RG.State.state = window.RG.State.resetState();
 

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,148 @@
+(() => {
+  const STORAGE_KEY = 'rg_settings_v1';
+
+  function load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return { inputOffsetMs: 0, difficulty: 'normal' };
+      const obj = JSON.parse(raw);
+      return {
+        inputOffsetMs: typeof obj.inputOffsetMs === 'number' ? obj.inputOffsetMs : 0,
+        difficulty: (obj.difficulty === 'veryeasy' || obj.difficulty === 'easy' || obj.difficulty === 'hard') ? obj.difficulty : 'normal'
+      };
+    } catch {
+      return { inputOffsetMs: 0, difficulty: 'normal' };
+    }
+  }
+
+  function save(s) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+    } catch {}
+  }
+
+  let cache = load();
+
+  function getInputOffsetMs() {
+    return cache.inputOffsetMs || 0;
+  }
+
+  function setInputOffsetMs(v) {
+    cache.inputOffsetMs = Math.max(-300, Math.min(300, Math.round(v)));
+    save(cache);
+  }
+
+  function getDifficulty() {
+    return cache.difficulty || 'normal';
+  }
+
+  function setDifficulty(d) {
+    const allowed = ['veryeasy','easy','normal','hard'];
+    cache.difficulty = allowed.includes(d) ? d : 'normal';
+    save(cache);
+  }
+
+  function openModal() {
+    const { settingsModal, settingsDifficulty, inputLagRange, inputLagNumber, difficultySelect } = window.RG.Dom;
+    if (!settingsModal) return;
+    // Prefill from current cache / controls
+    const currentDiff = (difficultySelect && difficultySelect.value) || getDifficulty();
+    if (settingsDifficulty) settingsDifficulty.value = currentDiff;
+    const off = getInputOffsetMs();
+    if (inputLagRange) inputLagRange.value = String(off);
+    if (inputLagNumber) inputLagNumber.value = String(off);
+
+    settingsModal.classList.remove('hidden');
+    settingsModal.setAttribute('aria-hidden', 'false');
+  }
+
+  function closeModal() {
+    const { settingsModal } = window.RG.Dom;
+    if (!settingsModal) return;
+    settingsModal.classList.add('hidden');
+    settingsModal.setAttribute('aria-hidden', 'true');
+  }
+
+  function init() {
+    const {
+      openSettingsBtn,
+      settingsModal,
+      settingsDifficulty,
+      inputLagRange,
+      inputLagNumber,
+      settingsSave,
+      settingsCancel,
+      difficultySelect,
+      statusEl
+    } = window.RG.Dom;
+
+    // Apply persisted difficulty to the visible control
+    if (difficultySelect) {
+      const d = getDifficulty();
+      difficultySelect.value = d;
+      // Trigger a layout update to match
+      window.RG.UI.applyKeyLayout();
+    }
+
+    // Wire open/close
+    if (openSettingsBtn) openSettingsBtn.addEventListener('click', openModal);
+    if (settingsModal) {
+      settingsModal.addEventListener('click', (e) => {
+        const t = e.target;
+        if (t && t.getAttribute && t.getAttribute('data-close')) {
+          closeModal();
+        }
+      });
+    }
+    if (settingsCancel) settingsCancel.addEventListener('click', closeModal);
+
+    // Sync range and number
+    function sync(val) {
+      if (inputLagRange) inputLagRange.value = String(val);
+      if (inputLagNumber) inputLagNumber.value = String(val);
+    }
+    if (inputLagRange) inputLagRange.addEventListener('input', () => sync(inputLagRange.value));
+    if (inputLagNumber) inputLagNumber.addEventListener('input', () => sync(inputLagNumber.value));
+
+    // Save
+    if (settingsSave) settingsSave.addEventListener('click', () => {
+      const diff = settingsDifficulty ? settingsDifficulty.value : 'normal';
+      const off = inputLagNumber ? Number(inputLagNumber.value) : 0;
+
+      setDifficulty(diff);
+      setInputOffsetMs(off);
+
+      if (difficultySelect) {
+        difficultySelect.value = diff;
+        const ev = new Event('change', { bubbles: true });
+        difficultySelect.dispatchEvent(ev);
+      }
+
+      if (statusEl) {
+        const f = window.RG.Dom.fileInput && window.RG.Dom.fileInput.files && window.RG.Dom.fileInput.files[0];
+        const diffName = window.RG.Difficulty.getDifficultyParams().name;
+        const offText = getInputOffsetMs();
+        if (f) {
+          statusEl.textContent = `Selected: ${f.name} — Difficulty: ${diffName}. Input offset ${offText} ms.`;
+        } else {
+          statusEl.textContent = `Ready — Difficulty: ${diffName}. Input offset ${offText} ms.`;
+        }
+      }
+
+      closeModal();
+    });
+
+    // Apply persisted offset immediately (no UI effect besides scheduling)
+    // Nothing else to do here; users feel it during play.
+  }
+
+  window.RG.Settings = {
+    init,
+    openModal,
+    closeModal,
+    getInputOffsetMs,
+    setInputOffsetMs,
+    getDifficulty,
+    setDifficulty
+  };
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -380,7 +380,7 @@ main {
   animation: comboBump 220ms ease-out;
 }
 
-/* Per-hit combo toast (e.g., \"12 combo!\") */
+/* Per-hit combo toast (e.g., "12 combo!") */
 .combo-toast {
   position: absolute;
   left: 50%;
@@ -498,4 +498,71 @@ footer {
   text-align: center;
   font-size: 12px;
   margin-top: 18px;
+}
+
+/* Modal */
+.modal.hidden { display: none; }
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+}
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 10, 22, 0.6);
+  backdrop-filter: blur(1px);
+}
+.modal-panel {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -54%);
+  width: min(520px, 92vw);
+  background: #0f1426;
+  border: 1px solid #1b2335;
+  border-radius: 10px;
+  box-shadow: 0 30px 80px rgba(0,0,0,0.6), inset 0 0 60px rgba(90, 120, 200, 0.08);
+}
+.modal-header {
+  padding: 14px 16px 8px;
+  border-bottom: 1px solid #1b2335;
+}
+.modal-header h2 {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.5px;
+  color: #eaf2ff;
+}
+.modal-body {
+  padding: 12px 16px;
+  display: grid;
+  gap: 14px;
+}
+.form-row {
+  display: grid;
+  gap: 8px;
+}
+.range-row {
+  display: grid;
+  grid-template-columns: 1fr 88px;
+  gap: 10px;
+  align-items: center;
+}
+.number {
+  appearance: none;
+  border: 1px solid #223152;
+  background: #12192e;
+  color: #d8e6ff;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+  width: 100%;
+}
+.modal-footer {
+  display: flex;
+  justify-content: end;
+  gap: 10px;
+  padding: 12px 16px 16px;
+  border-top: 1px solid #1b2335;
 }

--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
 
         <button id="analyzeBtn" class="btn" disabled>Analyze (precompute chart)</button>
         <button id="playChartBtn" class="btn primary" disabled>Play chart</button>
+
+        <button id="openSettingsBtn" class="btn">Settings</button>
         <small class="hint">Space to start/stop. If no file is selected, the microphone is used.</small>
       </div>
 
@@ -74,10 +76,46 @@
   <footer>
     <p>&copy; 2025 Your Name</p>
   </footer>
+
+  <!-- Settings Modal -->
+  <div id="settingsModal" class="modal hidden" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
+    <div class="modal-backdrop" data-close="1"></div>
+    <div class="modal-panel" role="document">
+      <header class="modal-header">
+        <h2 id="settingsTitle">Settings</h2>
+      </header>
+      <div class="modal-body">
+        <div class="form-row">
+          <label for="settingsDifficulty">Difficulty</label>
+          <select id="settingsDifficulty" class="select">
+            <option value="veryeasy">Very Easy</option>
+            <option value="easy">Easy</option>
+            <option value="normal">Normal</option>
+            <option value="hard">Hard</option>
+          </select>
+        </div>
+
+        <div class="form-row">
+          <label for="inputLag">Input offset (ms)</label>
+          <div class="range-row">
+            <input type="range" id="inputLag" min="-300" max="300" step="5">
+            <input type="number" id="inputLagNumber" class="number" min="-300" max="300" step="1">
+          </div>
+          <small class="muted">Use this if your hits feel late/early. Positive delays the hit window; negative makes it earlier.</small>
+        </div>
+      </div>
+      <footer class="modal-footer">
+        <button id="settingsCancel" class="btn">Cancel</button>
+        <button id="settingsSave" class="btn primary">Save</button>
+      </footer>
+    </div>
+  </div>
+
   <script src="assets/js/rg.js"></script>
   <script src="assets/js/constants.js"></script>
   <script src="assets/js/difficulty.js"></script>
   <script src="assets/js/dom.js"></script>
+  <script src="assets/js/settings.js"></script>
   <script src="assets/js/state.js"></script>
   <script src="assets/js/freq.js"></script>
   <script src="assets/js/algo.js"></script>
@@ -89,5 +127,3 @@
   <script src="assets/js/game.js"></script>
   <script src="assets/js/input.js"></script>
   <script src="assets/js/main.js"></script>
-</body>
-</html>


### PR DESCRIPTION
This PR introduces a settings modal that allows players to set the game difficulty and adjust for input lag. The changes include:

- A new settings modal in the HTML that provides a dropdown for difficulty selection and a range input for adjusting input lag.
- JavaScript functionality to load and save user preferences using local storage.
- Modifications to the existing game logic to integrate user-defined input lag offsets, improving the gameplay experience by allowing for personalized adjustments.

This addresses the need for customizable game settings, enhancing player experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [rhythm-game-test/oo9q0fmxdbil](https://cosine.wtf/cosine-stg/rhythm-game-test/task/oo9q0fmxdbil)
Author: Curtis Huang
